### PR TITLE
fix amc generated curs for varlen fields

### DIFF
--- a/cpp/amc/varlen.cpp
+++ b/cpp/amc/varlen.cpp
@@ -165,7 +165,9 @@ void amc::tfunc_Varlen_curs() {
             Ins(&R, curs_validq.body, "bool valid = ssizeof($Cpptype) <= curs.length;");
             if (field.p_arg->c_lenfld) {
                 Set(R, "$childlenexpr", LengthExpr(*field.p_arg, "(*($Cpptype*)curs.ptr)"));
-                Ins(&R, curs_validq.body, "valid = valid && $childlenexpr <= curs.length;");
+                // check that len is >= ssizeof($Cppexpr) && <= curs.length (remaining length)
+                // using unsigned comparison trick
+                Ins(&R, curs_validq.body, "valid = valid && unsigned($childlenexpr-ssizeof($Cpptype)) <= curs.length-ssizeof($Cpptype);");
             }
             Ins(&R, curs_validq.body, "return valid;");
         }

--- a/include/gen/atf_amc_gen.inl.h
+++ b/include/gen/atf_amc_gen.inl.h
@@ -5187,7 +5187,7 @@ inline void atf_amc::MsgLTV_v_curs_Reset(MsgLTV_v_curs &curs, atf_amc::MsgLTV &p
 // cursor points to valid item
 inline bool atf_amc::MsgLTV_v_curs_ValidQ(MsgLTV_v_curs &curs) {
     bool valid = ssizeof(atf_amc::MsgHdrLT) <= curs.length;
-    valid = valid && i32((*(atf_amc::MsgHdrLT*)curs.ptr).len + 2) <= curs.length;
+    valid = valid && unsigned(i32((*(atf_amc::MsgHdrLT*)curs.ptr).len + 2)-ssizeof(atf_amc::MsgHdrLT)) <= curs.length-ssizeof(atf_amc::MsgHdrLT);
     return valid;
 }
 


### PR DESCRIPTION
The curs is not valid if the msg has zero length.