### PR TITLE
win32 build - stage 1 - abt

### DIFF
--- a/bin/ai
+++ b/bin/ai
@@ -23,7 +23,7 @@ sub Die {
     print "error $_[0]. more info in txt/exe/abt/README.md\n";
     exit(1);
 }
-my $clean = scalar(grep(/^-clean$/,@ARGV)) || system("abt --version >/dev/null 2>/dev/null")!=0;
+my $clean = scalar(grep(/^-clean$/,@ARGV)) || (system("abt --version >/dev/null 2>/dev/null")!=0 && ! -x "bin/abt");
 @ARGV = grep(!/^-clean$/,@ARGV);
 # check if abt exists
 if ($clean) {

--- a/include/win32.h
+++ b/include/win32.h
@@ -53,6 +53,7 @@ extern "C" {
     };
     struct dirent {
         char d_name[MAX_PATH];
+        unsigned char d_type;
     };
     struct DIR {
         WIN32_FIND_DATA find_data;
@@ -60,14 +61,34 @@ extern "C" {
         int iter;
         bool eof;
         struct dirent dirent;
+        //char* path;
     };
     typedef HANDLE pthread_t;
     struct pthread_attr_t {
+        DWORD stack_size     = 0;
+        DWORD creation_flags = 0;
+        int detach_state     = 0;
     };
     typedef void* (*ThreadFunc)(void*);
 };
+
+/*posix style thread implementations*/
+typedef CRITICAL_SECTION pthread_mutex_t;
+#define PTHREAD_CREATE_JOINABLE 0
+#define PTHREAD_CREATE_DETACHED 1
+
+typedef struct {
+    ThreadFunc func;
+    void* arg;
+} ThreadStartInfo;
+
+static unsigned __
+
 int pthread_create(pthread_t *thread, pthread_attr_t *attr, ThreadFunc func, void *arg);
 pthread_t pthread_self();
+int pthread_join(pthread_t thread, void** ret);
+
+
 typedef int pid_t;
 int fork();
 int alarm(int sec);


### PR DESCRIPTION
Note - this is only the bootstrap portion to get a starting point for proper windows acr support. It successfully builds abt, src_hdr, src_func, and gcache build, but abt dies on an early error right now (will be handled in "stage 2").  the other binaries work as intended, verified by 

1. I wrapped all changes to cpp in `#if defined(WIN32)` blocks. I believe some of these changes would cause 0 issues on *nix builds - for example, casting - but better safe than sorry for now. That testing can occur later.
2.  The win32 build doesn't fit with the current workflow yet, so I added windows-specific .bat files. Dependencies are still being worked out, but this current commit just requires an openssl download (I added a script for a portable Perl download as well but it's unused)
3. It does not work with MSVS GUI yet (at least, I haven't tried) - so the build process is running `bin/win-ai.bat` from the command line (works on CMD, PS and MSVS Dev command prompt):
All 4 executables build, but the linker reports the following issues (TODO for next stage):
- error LNK2019: unresolved external symbol
    - workaround for now: `/FORCE:unresolved` in linker argument (causes LNK4088 warning)
        - algo::Attr_ReadStrptrMaybe is user-defined
        - `gcache`: openssl/EVP  symbols, `Sha1Ctx::Sha1Ctx`
- warning LNK4042: object specified more than once; extras ignored
    - all lib.algo object files. not causing issues, but annoying
- warning LNK4006: <symbol> already defined in <object>; second definition ignored
    - cpp.gen.src_func_gen.obj, cpp.gen.gcache_gen.obj, cpp.gen.abt_gen.obj


