### PR TITLE
enums args can be a required one

### DIFF
--- a/cpp/amc/global.cpp
+++ b/cpp/amc/global.cpp
@@ -579,7 +579,6 @@ bool amc::CmdArgRequiredQ(amc::FField &field) {
     return field.dflt.value=="" // no default provided...
         && !(field.arg == "algo.UnTime" || field.arg == "algo.UnDiff") // these can't be mandatory
         && !field.c_tary // not an array
-        && !c_fconst_N(*amc::GetEnumField(field)) // not an enum (these are always initialized)
         && CmdArgValueRequiredQ(field); // does require an arg
 }
 

--- a/cpp/gen/command_gen.cpp
+++ b/cpp/gen/command_gen.cpp
@@ -12012,6 +12012,7 @@ void command::atf_cmdline_Init(command::atf_cmdline& parent) {
     parent.amnum_n     	= 0; // (command.atf_cmdline.amnum)
     parent.amnum_max   	= 0; // (command.atf_cmdline.amnum)
     parent.fconst = u8(0);
+    parent.cconst = algo_MonthEnum(0);
     Regx_ReadSql(parent.dregx, "%", true);
     parent.dpkey = algo::strptr("");
 }
@@ -12173,10 +12174,12 @@ void command::atf_cmdline_PrintArgv(command::atf_cmdline& row, algo::cstring& st
         str << " -fconst:";
         strptr_PrintBash(temp,str);
     }
-    ch_RemoveAll(temp);
-    Month_Print(row.cconst, temp);
-    str << " -cconst:";
-    strptr_PrintBash(temp,str);
+    if (!(row.cconst == 0)) {
+        ch_RemoveAll(temp);
+        Month_Print(row.cconst, temp);
+        str << " -cconst:";
+        strptr_PrintBash(temp,str);
+    }
     if (!(row.dregx.expr == "%")) {
         ch_RemoveAll(temp);
         command::dregx_Print(const_cast<command::atf_cmdline&>(row), temp);
@@ -12604,7 +12607,7 @@ void command::atf_cmdline_ToArgv(command::atf_cmdline_proc& parent, algo::String
         command::fconst_Print(parent.cmd, *arg);
     }
 
-    if (true) {
+    if (parent.cmd.cconst != 0) {
         cstring *arg = &ary_Alloc(args);
         *arg << "-cconst:";
         Month_Print(parent.cmd.cconst, *arg);

--- a/data/dmmeta/field.ssim
+++ b/data/dmmeta/field.ssim
@@ -2921,7 +2921,7 @@ dmmeta.field  field:command.atf_cmdline.mnum  arg:i32  reftype:Tary  dflt:""  co
 dmmeta.field  field:command.atf_cmdline.mdbl  arg:double  reftype:Tary  dflt:""  comment:"Double array"
 dmmeta.field  field:command.atf_cmdline.amnum  arg:i32  reftype:Tary  dflt:""  comment:"Anon number array"
 dmmeta.field  field:command.atf_cmdline.fconst  arg:u8  reftype:Val  dflt:""  comment:"Fconst for field"
-dmmeta.field  field:command.atf_cmdline.cconst  arg:algo.Month  reftype:Val  dflt:""  comment:"Fconst for arg ctype"
+dmmeta.field  field:command.atf_cmdline.cconst  arg:algo.Month  reftype:Val  dflt:0  comment:"Fconst for arg ctype"
 dmmeta.field  field:command.atf_cmdline.dregx  arg:dmmeta.Ctype  reftype:RegxSql  dflt:'"%"'  comment:"Predefined regx"
 dmmeta.field  field:command.atf_cmdline.dpkey  arg:dmmeta.Ctype  reftype:Pkey  dflt:'""'  comment:"Predefined pkey"
 dmmeta.field  field:command.atf_comp.in  arg:algo.cstring  reftype:Val  dflt:'"data"'  comment:"Input directory or filename, - for stdin"

--- a/include/gen/command_gen.h
+++ b/include/gen/command_gen.h
@@ -2713,7 +2713,7 @@ struct atf_cmdline { // command.atf_cmdline
     u32                 amnum_n;       // number of elements in array
     u32                 amnum_max;     // max. capacity of array before realloc
     u8                  fconst;        //   0  Fconst for field
-    algo::Month         cconst;        // Fconst for arg ctype
+    algo::Month         cconst;        //   0  Fconst for arg ctype
     algo_lib::Regx      dregx;         //   "%"  Sql Regx of dmmeta::Ctype
     algo::Smallstr100   dpkey;         //   ""  Predefined pkey
     // func:command.atf_cmdline..AssignOp

--- a/test/atf_comp/atf_cmdline.MinimalExec
+++ b/test/atf_comp/atf_cmdline.MinimalExec
@@ -1,4 +1,4 @@
-bin/atf_cmdline  -astr:blah -anum:0 -adbl:0 -aflag:N -str:blah -cconst:None
+bin/atf_cmdline  -astr:blah -anum:0 -adbl:0 -aflag:N -str:blah
 astr:blah
 anum:0
 adbl:0

--- a/txt/protocol/command/README.md
+++ b/txt/protocol/command/README.md
@@ -364,7 +364,7 @@ Other ctypes in this namespace which don't have own readme files
 |mdbl|double|[Tary](/txt/exe/amc/reftypes.md#tary)||Double array|
 |amnum|i32|[Tary](/txt/exe/amc/reftypes.md#tary)||Anon number array|
 |fconst|u8|[Val](/txt/exe/amc/reftypes.md#val)||Fconst for field|
-|cconst|[algo.Month](/txt/protocol/algo/Month.md)|[Val](/txt/exe/amc/reftypes.md#val)||Fconst for arg ctype|
+|cconst|[algo.Month](/txt/protocol/algo/Month.md)|[Val](/txt/exe/amc/reftypes.md#val)|0|Fconst for arg ctype|
 |dregx|[dmmeta.Ctype](/txt/ssimdb/dmmeta/ctype.md)|[RegxSql](/txt/exe/amc/reftypes.md#regxsql)|"%"|Predefined regx|
 |dpkey|[dmmeta.Ctype](/txt/ssimdb/dmmeta/ctype.md)|[Pkey](/txt/exe/amc/reftypes.md#pkey)|""|Predefined pkey|
 


### PR DESCRIPTION
for example, when an arg comes from gconst we should be able to have
it set as required