### PR TITLE
README overhaul

### DIFF
--- a/txt/README.md
+++ b/txt/README.md
@@ -1,37 +1,90 @@
-## OpenACR
-<a href="#openacr"></a>
+# OpenACR
 
-This is OpenACR, a meta-programming language for generative systems programming.
-It consists of a powerful and extensible set of tools for creating programs and meta-algorithms,
-and writing code as data. OpenACR is published at [https://github.com/alexeilebedev/openacr](https://github.com/alexeilebedev/openacr)
+> A high-performance meta-programming language for building scalable systems with code generation.
 
-It is the result of over 15 years of development and
-production use. OpenACR was used to build mission-critical financial systems that handle hundreds of billions
-of messages daily at microsecond latencies, financial exchanges, distributed HFT platforms, CI systems, deployment systems, alerts
-and monitoring systems. It was also used to build itself -- 95% of all the source code here is generated
-by OpenACR's code generator (amc) from ascii relational tables.
+## Overview
+OpenACR is a comprehensive toolkit for building high-performance systems through code generation and meta-programming. It enables developers to create powerful, extensible applications by treating code as data and automating the generation of optimized system components.
 
-There are two key concepts in OpenACR: [Ssimfiles](ssim.md) and [C++ code generation](/txt/exe/amc/README.md).
+## Why OpenACR?
 
-The ideal use case is realized when it is taken as a core of a project, forming an ecosystem of commands and corresponding
-configuration data files, around which the project is grown an co-evolved with the schema.
-It can also be used if your project doesn't use C++ (in this case, focus on ssimfiles and [acr](/txt/exe/acr/README.md).
+- **Write Less, Do More**: Generate optimized C++ code automatically from simple schema definitions
+- **Scale with Confidence**: Used in production for 15+ years in high-stakes financial systems
+- **Future-Proof Architecture**: Treat code as data to evolve your system organically
+- **Developer-First Experience**: Human-readable configuration format that plays well with version control
 
-### Table Of Contents
-<a href="#table-of-contents"></a>
-<!-- dev.mdmark  mdmark:MDSECTION  state:BEG_AUTO  param:Toc -->
-<!-- dev.mdmark  mdmark:TOC  state:BEG_AUTO  param:Toc -->
-&#128196; [Setup And Installation](/txt/setup.md)<br/>
-&#128196; [Ssim Fundamentals](/txt/ssim.md)<br/>
-&#128193; [Recipes](/txt/recipe/README.md)<br/>
-&#128193; [Tutorials](/txt/tut/README.md)<br/>
-&#128193; [Ssim Databases](/txt/ssimdb/README.md)<br/>
-&#128193; [Executables](/txt/exe/README.md)<br/>
-&#128193; [Libraries](/txt/lib/README.md)<br/>
-&#128193; [Protocols](/txt/protocol/README.md)<br/>
-&#128193; [Scripts](/txt/script/README.md)<br/>
+### Proven Performance
+OpenACR has been maintained, improved, and used in production for over 15 years. It was originally created for (and matured at) the New York Stock Exchange<!-- *Well technically, it was originally created at Algo Inc, which was then acquired by NYSE to develop pillar -->, where all aspects of a system are critically important. As such, it was meticulously designed to maintain and outperform regulated standards of speed, availability, and throughput, while maintaining the flexibility of its design principles.
 
-<!-- dev.mdmark  mdmark:TOC  state:END_AUTO  param:Toc -->
+Now, it powers...
 
-<!-- dev.mdmark  mdmark:MDSECTION  state:END_AUTO  param:Toc -->
+📈 ...ultra-low-latency trading systems processing hundreds of billions of messages daily, such as [Pillar](https://www.nyse.com/pillar)
 
+🌀 ...high-throughput data streaming platforms running at 1tbps such as [AlgoX2](https://algox2.com/)
+
+👀 ...high-availability real-time monitors across infrastructures of thousands of servers
+
+🤖 ...complex CI/CD pipelines and infrastructure orchestration systems
+
+🔄 ...itself! 95% of OpenACR's source code is generated using its own code generator.
+
+and more!
+
+## Key Features
+
+### 📝 Schema-First Development
+- Define your system architecture using ssimfiles - a lightweight, relational format
+- Clean separation of data and logic
+- Version-control friendly
+- Perfect for rapid prototyping
+
+### 🚀 Automated Code Generation
+- Optimized C++ data structures and validation logic
+- Efficient access paths and indexes
+- Rich data structure support (hash tables, binary heaps, trees)
+- Language-agnostic schema format (more languages planned)
+
+### 🔧 Flexible Integration
+- Enhance existing projects incrementally
+- Pick and choose what to manage with OpenACR
+- Comprehensive standard library
+- Use the schema system even without C++
+  
+
+
+
+## Installation
+1. Clone the repository
+```bash
+git clone https://github.com/alexeilebedev/openacr.git
+cd openacr
+``` 
+2. Install dependencies:
+```bash
+# Ubuntu/Debian
+sudo apt install -y mariadb-server mariadb-client libmariadb-dev libssl-dev liblz4-dev cppcheck
+
+# CentOS
+sudo yum install -y mariadb mariadb-devel mariadb-server
+```
+3. Build
+```bash
+bin/ai
+```
+
+## Contributing
+
+Contributions are welcome! If you'd like to help improve OpenACR, feel free to:
+- 🐛 Report bugs and issues
+- 💡 Suggest new features
+- 📝 Improve documentation
+- 🔧 Submit pull requests
+
+Please review the Contributing Guidelines before getting started.
+
+## 💬 Community
+Join the new [Discord](https://discord.gg/ZmbsvPzUAX)
+
+
+## License
+
+OpenACR is licensed under the GNU General Public License (GPL). See [LICENSE](https://github.com/alexeilebedev/openacr/blob/master/LICENSE) for details.


### PR DESCRIPTION
common complaint I've heard from people is that the readme is too terse/whitepapery/product-pitchy

We can add CI badges and diagrams later but this is enough for now